### PR TITLE
Added ImGuiInputTextFlags_WordWrap flag to multiline inputs

### DIFF
--- a/src/UI.cpp
+++ b/src/UI.cpp
@@ -3266,7 +3266,8 @@ void UI::RenderPropertiesPanel(Model& model, IconManager& icons, JobQueue& jobs,
                 strncpy(notesBuf, room->notes.c_str(), sizeof(notesBuf) - 1);
                 if (ImGui::InputTextMultiline("##description", notesBuf, 
                                              sizeof(notesBuf), 
-                                             ImVec2(-1, 80))) {
+                                             ImVec2(-1, 80),
+                                             ImGuiInputTextFlags_WordWrap)) {
                     room->notes = notesBuf;
                     model.MarkDirty();
                 }
@@ -3583,7 +3584,8 @@ void UI::RenderPropertiesPanel(Model& model, IconManager& icons, JobQueue& jobs,
                 descBuf[sizeof(descBuf) - 1] = '\0';
                 if (ImGui::InputTextMultiline("##regionDescription", descBuf, 
                                              sizeof(descBuf), 
-                                             ImVec2(-1, 80))) {
+                                             ImVec2(-1, 80),
+                                             ImGuiInputTextFlags_WordWrap)) {
                     region->description = descBuf;
                     model.MarkDirty();
                 }

--- a/src/UI/Modals.cpp
+++ b/src/UI/Modals.cpp
@@ -961,7 +961,7 @@ void Modals::RenderSettingsModal(App& app, Model& model, KeymapManager& keymap) 
         if (ImGui::InputTextMultiline("##description", descBuf, 
                                       sizeof(descBuf),
                                       ImVec2(-1, 120.0f),
-                                      ImGuiInputTextFlags_AllowTabInput)) {
+                                      ImGuiInputTextFlags_WordWrap)) {
             model.meta.description = descBuf;
             model.MarkDirty();
         }


### PR DESCRIPTION
Before (ImGuiInputTextFlags_AllowTabInput):

<img width="595" height="133" alt="Image" src="https://github.com/user-attachments/assets/4b74a362-6942-49bc-98e7-7193a1815983" />

After (ImGuiInputTextFlags_WordWrap):

<img width="592" height="130" alt="Image" src="https://github.com/user-attachments/assets/890ff815-b71a-4637-9577-71df2b023754" />